### PR TITLE
SERV-1108

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To output a recursive listing of the object direcotry, with the default being a 
 
 Ptcp is a cp-like tool that can copy files and folders in and out of the Pairtree structure. Unlike Linux's cp, the default is recursive. Ptcp's defualt behavior will also not overwrite files or directories if they already exist at the specificed location. Instead, it will add `.x` (x being an integer that starts from 1) to the path. 
 
-This cp tool behaves similarly to the unix cp in relation to directories. This means that when you are copying from `SRC` to `DEST` if the folder does not exist, the folder will be created and only the contents of the src will be copied into `DEST`. If the folder does exist, the folder and its contents from `SRC` will be moved into `DEST`. When wanting to copy into a subpath or new path in the pairtree, the `-n` flag will need to be used and is detailed below. At the moment the ability to copy from one pairtree to another pairtree is not available. 
+This cp tool behaves similarly to the unix cp in relation to directories. This means that when you are copying from `SRC` to `DEST` if the folder does not exist, the folder will be created and only the contents of the src will be copied into `DEST`. If the folder does exist, the folder and its contents from `SRC` will be moved into `DEST`. When wanting to copy into a subpath or new path in the pairtree, the `-n` flag will need to be used and is detailed below. When trying to copy a single file from the pairtree into a `Dest` that does not exist, an erorr will be thrown. At the moment the ability to copy from one pairtree to another pairtree is not available. 
 
 When an ENV PAIRTREE_ROOT is set, the basic command is
     
@@ -107,10 +107,6 @@ When an ENV PAIRTREE_ROOT, the basic command is
 When an ENV PAIRTREE_ROOT is not set, the command is 
 
     ptmv [PT_ROOT] [ID] [/path/to/output/]
-
-To specify the path from which to remove files when copying into the Pairtree, use -t as a prefix 
-
-    ptmv -t [/path/to/] [/path/to/file.ext] [ID]
 
 To produce a tar/gzipped output or upack a tar/gzipped in the pairtree structure run 
 

--- a/cmd/ptcp/ptcp_test.go
+++ b/cmd/ptcp/ptcp_test.go
@@ -53,6 +53,22 @@ func TestPTCP(t *testing.T) {
 			expectErr: nil,
 		},
 		{
+			name:      "dest is new pairtree",
+			src:       "",
+			dest:      "ark:/b2345",
+			subpath:   "",
+			pairpath:  filepath.Join("b2", "34", "5", "b2345"),
+			expectErr: nil,
+		},
+		{
+			name:      "dest does not exist source is file",
+			src:       "ark:/b5488",
+			dest:      "",
+			subpath:   "outerb5488.txt",
+			pairpath:  filepath.Join("b5", "48", "8", "b5488", "outerb5488.txt"),
+			expectErr: error_msgs.Err14,
+		},
+		{
 			name:      "dest is pairtree has subpath",
 			src:       "",
 			dest:      "ark:/b5488",
@@ -84,7 +100,10 @@ func TestPTCP(t *testing.T) {
 			var finalSrc string
 			var finalDest string
 			srcDir := testutils.CreateTempDir(t, fs)
-			destDir := testutils.CreateTempDir(t, fs)
+			destDir := ""
+			if test.name != "dest does not exist source is file" {
+				destDir = testutils.CreateTempDir(t, fs)
+			}
 			if test.src == "" {
 				//pairtree is the dest
 				testutils.CopyTestDirectory(t, testutils.TestPairtree, destDir)
@@ -117,56 +136,12 @@ func TestPTCP(t *testing.T) {
 	}
 }
 
+// TestTar tests if an object in the pairtree is properly tared outside of it
 func TestTar(t *testing.T) {
-	tests := []struct {
-		name      string
-		src       string
-		dest      string
-		subpath   string
-		pairpath  string
-		expectErr error
-	}{
-		{
-			name:      "src is pairtree no subpath",
-			src:       "ark:/b5488",
-			dest:      "",
-			pairpath:  filepath.Join("b5", "48", "8", "b5488"),
-			subpath:   "",
-			expectErr: nil,
-		},
-		{
-			name:      "src is pairtree has subpath",
-			src:       "ark:/b5488",
-			dest:      "",
-			subpath:   "folder",
-			pairpath:  filepath.Join("b5", "48", "8", "b5488", "folder"),
-			expectErr: nil,
-		},
-		{
-			name:      "dest is pairtree no subpath",
-			src:       "",
-			dest:      "ark:/b5488",
-			subpath:   "",
-			pairpath:  filepath.Join("b5", "48", "8", "b5488"),
-			expectErr: nil,
-		},
-		{
-			name:      "dest is pairtree has subpath",
-			src:       "",
-			dest:      "ark:/b5488",
-			subpath:   "folder",
-			pairpath:  filepath.Join("b5", "48", "8", "b5488", "folder"),
-			expectErr: nil,
-		},
-		{
-			name:      "src and dest are both not pairtree",
-			src:       "source",
-			dest:      "",
-			subpath:   "",
-			pairpath:  "",
-			expectErr: error_msgs.Err10,
-		},
-	}
+	var buf bytes.Buffer
+	var args []string
+	src := "ark:/a5388"
+	tgzFile := "ark+=a5388.tgz"
 
 	// Create a logger instance using the registered sink.
 	logger, cleanup := testutils.SetupLogger(logFile)
@@ -175,47 +150,24 @@ func TestTar(t *testing.T) {
 
 	fs := afero.NewOsFs()
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			var args []string
-			var finalSrc string
-			var finalDest string
-			srcDir := testutils.CreateTempDir(t, fs)
-			destDir := testutils.CreateTempDir(t, fs)
-			if test.src == "" {
-				//pairtree is the dest
-				testutils.CopyTestDirectory(t, testutils.TestPairtree, destDir)
-				// create file to copy to dest
-				fileInSrc := testutils.CreateFileInDir(t, srcDir, "file.txt")
-				args = []string{root + destDir, fileInSrc, test.dest}
-				finalSrc = srcDir
-				finalDest = filepath.Join(destDir, rootDir, test.pairpath)
+	srcDir := testutils.CreateTempDir(t, fs)
+	destDir := testutils.CreateTempDir(t, fs)
+	testutils.CopyTestDirectory(t, testutils.TestPairtree, srcDir)
 
-			} else {
-				// pairtree is the src
-				testutils.CopyTestDirectory(t, testutils.TestPairtree, srcDir)
-				args = []string{root + srcDir, test.src, destDir}
-				finalSrc = filepath.Join(srcDir, rootDir, test.pairpath)
-				finalDest = filepath.Join(destDir, filepath.Base(test.pairpath))
-			}
+	destDir = filepath.Join(destDir, tgzFile)
 
-			if test.subpath != "" {
-				args = append(args, "-n"+test.subpath)
-			}
+	args = []string{root + srcDir, src, destDir, "-a"}
 
-			err := Run(args, &buf)
-			require.ErrorIs(t, err, test.expectErr)
+	err := Run(args, &buf)
+	require.ErrorIs(t, err, nil)
 
-			if test.expectErr == nil {
-
-				err = testutils.CheckDirCopy(fs, finalSrc, finalDest, filepath.Base(test.pairpath))
-				assert.NoError(t, err, "Expected no error, but got one")
-			}
-		})
-	}
+	// Check if the destination file exists
+	exists, err := afero.Exists(fs, destDir)
+	assert.ErrorIs(t, err, nil, "Failed to check if dirSrc was copied: %v", err)
+	assert.True(t, exists, "File was not copied to destination")
 }
 
+// TestUnTar tests untarring a .tgz into a pairtree object
 func TestUnTar(t *testing.T) {
 	var buf bytes.Buffer
 	var args []string

--- a/cmd/ptls/ptls.go
+++ b/cmd/ptls/ptls.go
@@ -57,7 +57,7 @@ func Run(args []string, writer io.Writer) error {
 	var pairPath string
 
 	var rootCmd = &cobra.Command{
-		Use:   "ptls [PT_ROOT] [FLAGS] [ID]",
+		Use:   "ptls -p [PT_ROOT] [FLAGS] [ID]",
 		Short: "ptls is a tool to list Pairtree object directories.",
 		Long:  "A tool to list contents of Pairtree object directories with various options.",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/ptmv/ptmv.go
+++ b/cmd/ptmv/ptmv.go
@@ -1,0 +1,169 @@
+package ptmv
+
+/* ptmv is a tool that can move files in and out of the Pairtree structure */
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	error_msgs "github.com/UCLALibrary/pt-tools/pkg/error-msgs"
+	"github.com/UCLALibrary/pt-tools/pkg/pairtree"
+	"github.com/UCLALibrary/pt-tools/utils"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var (
+	tar     bool
+	ptRoot  string
+	logFile string      = "logs.log"
+	Logger  *zap.Logger = utils.Logger(logFile)
+	src     string      = ""
+	dest    string      = ""
+)
+
+func initFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&ptRoot, "pairtree", "p", "", "Set pairtree root directory")
+	cmd.Flags().BoolVarP(&tar, "a", "a", false, "Produce a tar/gzipped output or unpack a tar/gzipped")
+}
+
+func Run(args []string, writer io.Writer) error {
+	var err error
+
+	var rootCmd = &cobra.Command{
+		Use:   "ptmv [PT_ROOT] [ID] [/path/to/output/]",
+		Short: "Ptmv is a tool that can move files in and out of the Pairtree structure",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// If the root has not been set yet check the ENV vars
+			if ptRoot == "" {
+
+				if envVar := os.Getenv("PAIRTREE_ROOT"); envVar != "" {
+					ptRoot = envVar
+				} else {
+					fmt.Fprintln(writer, error_msgs.Err7)
+					return error_msgs.Err7
+				}
+			}
+
+			numArgs := len(args)
+			if numArgs < 2 {
+				fmt.Fprintln(writer, "Please provide a source and destination for copied files")
+				Logger.Error("There are not enough arguments to ptmv",
+					zap.Error(error_msgs.Err9))
+
+				return error_msgs.Err9
+			}
+
+			if numArgs == 2 {
+				// Extract the src and dest
+				src = args[numArgs-2]
+				dest = args[numArgs-1]
+			} else {
+				fmt.Fprintln(writer, "Too many arguments were provided to ptmv")
+				Logger.Error("Error parsing ptmv", zap.Error(error_msgs.Err8))
+
+				return error_msgs.Err8
+			}
+
+			Logger.Info("Pairtree root is", zap.String("PAIRTREE_ROOT", ptRoot))
+
+			return nil
+		},
+	}
+
+	initFlags(rootCmd)
+	rootCmd.SetOut(writer)
+	rootCmd.SetErr(writer)
+	rootCmd.SetArgs(args)
+
+	utils.ApplyExitOnHelp(rootCmd, 0)
+
+	if err = rootCmd.Execute(); err != nil {
+		Logger.Error("Error setting command line", zap.Error(err))
+		return err
+	}
+
+	// check if the pairtree version file exists and is populated
+	if err := pairtree.CheckPTVer(ptRoot); err != nil {
+		Logger.Error("Error with pairtree veresion file", zap.Error(err))
+		return err
+	}
+
+	// Get the prefix from pairtree_prefix file
+	prefix, err := pairtree.GetPrefix(ptRoot)
+
+	if err != nil {
+		Logger.Error("Error retrieving prefix from pairtree_prefix file", zap.Error(err))
+		return err
+	}
+
+	if prefix == "" {
+		prefix = pairtree.PtPrefix
+	}
+
+	srcIsPairtree := false
+	// Determine if the src or dest is the pairtree
+	if strings.HasPrefix(src, prefix) {
+		if src, err = pairtree.CreatePP(src, ptRoot, prefix); err != nil {
+			Logger.Error("Error creating pairpath", zap.Error(err))
+			return err
+		}
+		src = filepath.Join(src)
+		srcIsPairtree = true
+	} else if strings.HasPrefix(dest, prefix) {
+		if dest, err = pairtree.CreatePP(dest, ptRoot, prefix); err != nil {
+			Logger.Error("Error creating pairpath", zap.Error(err))
+			return err
+		}
+		if err = pairtree.CreateDirNotExist(dest); err != nil {
+			return err
+		}
+		dest = filepath.Join(dest)
+	} else {
+		fmt.Fprintln(writer,
+			"Neither the source or destination contains a prefix and is not a part of the pairtree")
+		Logger.Error("Error verifying source and destination",
+			zap.Error(error_msgs.Err10))
+		return error_msgs.Err10
+	}
+
+	fmt.Printf("This is the src: %s \n", src)
+	fmt.Printf("This is the dest: %s \n", dest)
+
+	if err := os.RemoveAll(dest); err != nil {
+		return fmt.Errorf("failed to remove %s: %w", dest, err)
+	}
+
+	if tar {
+		if srcIsPairtree {
+			if err = pairtree.TarGz(src, dest, prefix, true); err != nil {
+				Logger.Error("Error compressing pairtree object", zap.Error(err))
+				return err
+			}
+		} else {
+			if err = pairtree.UnTarGz(src, dest); err != nil {
+				Logger.Error("Error decompressing .tgz file", zap.Error(err))
+				return err
+			}
+		}
+	} else {
+
+		finalDest, err := pairtree.CopyFileOrFolder(src, dest, true)
+
+		if err != nil {
+			Logger.Error("Error copying source to destination", zap.Error(err))
+			return err
+		} else {
+			Logger.Info("Folder or file was successfully copied to",
+				zap.String("destination of File or Folder", finalDest))
+		}
+	}
+
+	if err := os.RemoveAll(src); err != nil {
+		return fmt.Errorf("failed to remove %s: %w", src, err)
+	}
+	return nil
+}

--- a/cmd/ptmv/ptmv_test.go
+++ b/cmd/ptmv/ptmv_test.go
@@ -8,7 +8,6 @@ import (
 
 	error_msgs "github.com/UCLALibrary/pt-tools/pkg/error-msgs"
 	"github.com/UCLALibrary/pt-tools/testutils"
-	"github.com/mholt/archiver"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -100,95 +99,32 @@ func TestPTMV(t *testing.T) {
 
 // TestTar tests if an object in the pairtree is properly tared outside of it
 func TestTar(t *testing.T) {
-	var buf bytes.Buffer
-	var args []string
-	src := "ark:/a5388"
-	tgzFile := "ark+=a5388.tgz"
-	pairpath := filepath.Join("a5", "38", "8", "a5388")
-
 	// Create a logger instance using the registered sink.
 	logger, cleanup := testutils.SetupLogger(logFile)
 	defer cleanup()
 	Logger = logger
 
-	fs := afero.NewOsFs()
+	src := "ark:/a5388"
+	tgzFile := "ark+=a5388.tgz"
 
-	srcDir := testutils.CreateTempDir(t, fs)
-	testutils.CopyTestDirectory(t, testutils.TestPairtree, srcDir)
+	err := testutils.TarCli(t, Run, src, tgzFile)
+	assert.ErrorIs(t, err, nil, "There was an error with the Tar aspect of ptmv %v", err)
 
-	destDir := testutils.CreateTempDir(t, fs)
-	destDir = filepath.Join(destDir, tgzFile)
-
-	args = []string{root + srcDir, src, destDir, "-a"}
-	fullSrc := filepath.Join(srcDir, pairpath)
-	err := Run(args, &buf)
-	require.ErrorIs(t, err, nil)
-
-	// Check if the destination file exists
-	exists, err := afero.Exists(fs, destDir)
-	assert.ErrorIs(t, err, nil, "Failed to check if dirSrc was copied: %v", err)
-	assert.True(t, exists, "File was not copied to destination")
-
-	// check if the src was deleted
-	_, err = os.Stat(fullSrc)
-	assert.True(t, os.IsNotExist(err), "Expected path to not exist, but got: %v", err)
 }
 
 // TestUnTar tests a .tgz file is properly untarred into the pairtree
 func TestUnTar(t *testing.T) {
-	var buf bytes.Buffer
-	var args []string
+	// Create a logger instance using the registered sink.
+	logger, cleanup := testutils.SetupLogger(logFile)
+	defer cleanup()
+	Logger = logger
 
 	dest := "ark:/a5388"
 	pairpath := filepath.Join(rootDir, "a5", "38", "8", "a5388")
 	ppBase := "a5388"
 
-	// Create a logger instance using the registered sink.
-	logger, cleanup := testutils.SetupLogger(logFile)
-	defer cleanup()
-	Logger = logger
-
-	fs := afero.NewOsFs()
-	srcDir := testutils.CreateTempDir(t, fs)
-	destDir := testutils.CreateTempDir(t, fs)
-	pairpath = filepath.Join(destDir, pairpath)
-
-	testutils.CopyTestDirectory(t, testutils.TestPairtree, destDir)
-
-	// Add files to src and .tgz file
-	dirTGZ := testutils.CreateDirInDir(t, fs, srcDir, ppBase)
-
-	dirSrcTGZ := filepath.Join(srcDir, ppBase+".tgz")
-
-	fileNames := []string{"file.txt", "file1.txt", "file2.txt"}
-	for _, fileName := range fileNames {
-		_ = testutils.CreateFileInDir(t, dirTGZ, fileName)
-	}
-
-	// Archive the source directory
-	tgz := archiver.NewTarGz()
-
-	if err := tgz.Archive([]string{dirTGZ}, dirSrcTGZ); err != nil {
-		t.Fatalf("There was an error archiving the folder %v", err)
-	}
-
-	args = []string{root + destDir, dirSrcTGZ, dest, "-a"}
-	err := Run(args, &buf)
-	require.ErrorIs(t, err, nil)
-
-	// Check if source files were read properly
-	files, err := afero.ReadDir(fs, pairpath)
-	assert.ErrorIs(t, err, nil, "Failed to read dirSrc contents: %v", err)
-
-	// Further checks can compare individual file names and contents
-	for i, srcFile := range files {
-		assert.Equal(t, srcFile.Name(), fileNames[i], "File names do not match")
-	}
-
-	// check if the src was deleted
-	_, err = os.Stat(dirSrcTGZ)
-	assert.True(t, os.IsNotExist(err), "Expected path to not exist, but got: %v", err)
-
+	err := testutils.UntarCLI(t, Run, dest, pairpath, ppBase, true)
+	assert.ErrorIs(t, err, nil)
 }
 
 // TestCLIError tests if an error is thrown when various CLI options are missing or are wrong

--- a/cmd/ptrm/ptrm.go
+++ b/cmd/ptrm/ptrm.go
@@ -42,7 +42,7 @@ func Run(args []string, writer io.Writer) error {
 	var pairPath string
 
 	var rootCmd = &cobra.Command{
-		Use:   "ptrm [PT_ROOT] [ID] [subpath/to/file.txt]",
+		Use:   "ptrm -p [PT_ROOT] [ID] [subpath/to/file.txt]",
 		Short: "ptrm is a tool to remove Pairtree objects, files, and directores",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If the root has not been set yet check the ENV vars

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/UCLALibrary/pt-tools/cmd/ptcp"
 	"github.com/UCLALibrary/pt-tools/cmd/ptls"
+	"github.com/UCLALibrary/pt-tools/cmd/ptmv"
 	"github.com/UCLALibrary/pt-tools/cmd/ptrm"
 )
 
@@ -35,6 +36,11 @@ func main() {
 		}
 	case "ptcp":
 		err := ptcp.Run(args, writer)
+		if err != nil {
+			os.Exit(1)
+		}
+	case "ptmv":
+		err := ptmv.Run(args, writer)
 		if err != nil {
 			os.Exit(1)
 		}

--- a/pkg/error-msgs/error_msgs.go
+++ b/pkg/error-msgs/error_msgs.go
@@ -16,4 +16,5 @@ var (
 	Err11 = errors.New("the -n and -a options can not be used together in ptcp")
 	Err12 = errors.New("temp directory does not contain exactly one folder")
 	Err13 = errors.New("folder name does not match pairtree ID")
+	Err14 = errors.New("the destination path does not exist and the src is a file")
 )

--- a/pkg/pairtree/pairtree.go
+++ b/pkg/pairtree/pairtree.go
@@ -105,6 +105,17 @@ func CheckPTVer(ptRoot string) error {
 	}
 }
 
+// CreateDirNotExist creates a directory if the path does not exist
+func CreateDirNotExist(path string) error {
+	// If the destination is a directory, ensure it has the correct path
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // CreatePP creates the full pairpath given the root, id, and prefix giving the pairpath to an object
 func CreatePP(id, ptRoot, prefix string) (string, error) {
 	if strings.TrimSpace(ptRoot) == "" {

--- a/pkg/pairtree/pairtree_test.go
+++ b/pkg/pairtree/pairtree_test.go
@@ -778,6 +778,7 @@ func TestDeletePairtreeItem(t *testing.T) {
 	}
 }
 
+// TestCopyFile tests copying files into directories
 func TestCopyFile(t *testing.T) {
 
 	testFiles := []struct {
@@ -785,11 +786,12 @@ func TestCopyFile(t *testing.T) {
 		fileName       string
 		changeFileName bool
 		overwrite      bool
+		createDest     bool
 		expectError    error
 	}{
 		{
 			testName:       "No overwrite and change file name",
-			fileName:       "newfilename.txt",
+			fileName:       "newfilename",
 			changeFileName: true,
 			overwrite:      true,
 			expectError:    nil,
@@ -861,6 +863,7 @@ func TestCopyFile(t *testing.T) {
 	}
 }
 
+// TestCopyFolder tests copying a directory into another directory
 func TestCopyFolder(t *testing.T) {
 	testFolders := []struct {
 		testName         string
@@ -1140,7 +1143,7 @@ func TestUnTarGz(t *testing.T) {
 			for _, fileName := range fileNames {
 				_ = testutils.CreateFileInDir(t, dirTGZ, fileName)
 			}
-			sourceFolders := []string{dirTGZ} 
+			sourceFolders := []string{dirTGZ}
 
 			if test.addFolder {
 				pathToFolder := testutils.CreateDirInDir(t, fs, tempDir, "extraFolder")


### PR DESCRIPTION
- fix bugs that were found in PTCP 
    - I had previously (accidentally) deleted the test for TestTar and replaced it with TestPTCP
    - There was an issue with copying a file into a directory that does not exist. We decided that this behavior will not be allowed if the directory is not in the pairtree 
- Create tests and ptmv tool 