### PR TITLE
[SERV-1171] Fix PTCP to better match linux cp

### DIFF
--- a/cmd/ptcp/ptcp.go
+++ b/cmd/ptcp/ptcp.go
@@ -40,7 +40,7 @@ func Run(args []string, writer io.Writer) error {
 
 	var rootCmd = &cobra.Command{
 		Use:   "ptcp -p [PT_ROOT] [ID] [/path/to/output]",
-		Short: "ptrm is a tool to copy files and folders in and out of the Pairtree",
+		Short: "ptcp is a tool to copy files and folders in and out of the Pairtree",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If the root has not been set yet check the ENV vars
 			if ptRoot == "" {
@@ -122,14 +122,6 @@ func Run(args []string, writer io.Writer) error {
 			return err
 		}
 		src = filepath.Join(src, subpath)
-		//if the destination doesnt exist and the src is a file return an error
-		if info, err := os.Stat(src); err == nil && !info.IsDir() {
-			if _, err := os.Stat(dest); os.IsNotExist(err) {
-				Logger.Error("Error with destination", zap.Error(error_msgs.Err14))
-				return error_msgs.Err14
-			}
-		}
-
 		srcIsPairtree = true
 	} else if strings.HasPrefix(dest, prefix) {
 		if dest, err = pairtree.CreatePP(dest, ptRoot, prefix); err != nil {

--- a/cmd/ptcp/ptcp_test.go
+++ b/cmd/ptcp/ptcp_test.go
@@ -60,14 +60,6 @@ func TestPTCP(t *testing.T) {
 			expectErr: nil,
 		},
 		{
-			name:      "dest does not exist source is file",
-			src:       "ark:/b5488",
-			dest:      "",
-			subpath:   "outerb5488.txt",
-			pairpath:  filepath.Join("b5", "48", "8", "b5488", "outerb5488.txt"),
-			expectErr: error_msgs.Err14,
-		},
-		{
 			name:      "dest is pairtree has subpath",
 			src:       "",
 			dest:      "ark:/b5488",
@@ -99,10 +91,7 @@ func TestPTCP(t *testing.T) {
 			var finalSrc string
 			var finalDest string
 			srcDir := testutils.CreateTempDir(t, fs)
-			destDir := ""
-			if test.name != "dest does not exist source is file" {
-				destDir = testutils.CreateTempDir(t, fs)
-			}
+			destDir := testutils.CreateTempDir(t, fs)
 			if test.src == "" {
 				//pairtree is the dest
 				testutils.CopyTestDirectory(t, testutils.TestPairtree, destDir)
@@ -111,7 +100,6 @@ func TestPTCP(t *testing.T) {
 				args = []string{root + destDir, fileInSrc, test.dest}
 				finalSrc = srcDir
 				finalDest = filepath.Join(destDir, rootDir, test.pairpath)
-
 			} else {
 				// pairtree is the src
 				testutils.CopyTestDirectory(t, testutils.TestPairtree, srcDir)

--- a/pkg/error-msgs/error_msgs.go
+++ b/pkg/error-msgs/error_msgs.go
@@ -16,6 +16,5 @@ var (
 	Err11 = errors.New("the -n and -a options can not be used together in ptcp")
 	Err12 = errors.New("temp directory does not contain exactly one folder")
 	Err13 = errors.New("folder name does not match pairtree ID")
-	Err14 = errors.New("the destination path does not exist and the src is a file")
 	Err15 = errors.New("the path cannot be an empty string")
 )


### PR DESCRIPTION
- Remove a check that was no longer necessary and the test that was associated with it
- Remove one of the error messages that was specific to that check